### PR TITLE
Avoid targeting `::before` in tab-pane styling

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -106,22 +106,24 @@
         opacity: 1;
       }
 
-      &:before {
+      &:after {
         content: '';
         width: 100%;
         background-image: linear-gradient(to left, #7ec1ff, #478dff);
         height: 2px;
         position: absolute;
         left: 0;
+        top: 0;
       }
     }
 
     .title {
-      &:before {
+      &:after {
         content:'';
         display:inline-block;
         position: relative;
         width:16px;
+        top: 0;
       }
     }
   }


### PR DESCRIPTION
This PR solves a styling conflict with the [`file-icons`](https://atom.io/packages/file-icons) package, which uses `::before` to display icons in file tabs. Currently, the tab-icons are missing because City Lights is replacing the pseudo-element with a bright blue bar.

This issue is easily remedied by using `::after` instead.

Resolves file-icons/atom#745.