### PR TITLE
Use indirect reference on tree view tab

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,4 @@
 root = document.documentElement
-treeViewTab = root.querySelector '.tab[data-type="TreeView"]'
-treeViewTitles = document.querySelectorAll('.tree-view span.name')
 
 module.exports =
   activate: (state) ->
@@ -25,11 +23,9 @@ module.exports =
 
 
 showTabBarInTreeView = (boolean) ->
-  if boolean
-    treeViewTab.parentElement.style.display = 'flex'
-  else
-    treeViewTab.parentElement.style.display = 'none'
-
+  treeViewTab = root.querySelector '.tab[data-type="TreeView"]'
+  if treeViewTab?
+      treeViewTab.parentElement.style.display = if boolean then 'flex' else 'none'
 
 setSize = (currentFontSize) ->
   root.style.fontSize = currentFontSize + 'px'
@@ -39,6 +35,7 @@ setSize = (currentFontSize) ->
     root.style.lineHeight = 2.1
 
 unsetSize = () ->
+  treeViewTitles = document.querySelectorAll('.tree-view span.name')
   for span, i in treeViewTitles
     span.style.fontSize = ''
 
@@ -66,10 +63,11 @@ changeTabBarSize = (tabValue) ->
 observeEditorsOnEvents = ->
   tabSizeValue = atom.config.get('city-lights-ui.tabSize')
   fontSizeValue = atom.config.get('city-lights-ui.fontSize')
+  showTabBarInTreeView()
   setSize(fontSizeValue)
   changeTabBarSize(tabSizeValue)
 
-atom.workspace.observeActivePaneItem (editor) ->
+atom.workspace.observePaneItems (item) ->
   observeEditorsOnEvents()
 
 atom.workspace.observeTextEditors (editor) ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,5 @@
 root = document.documentElement
-tabsInTreeView = root.querySelector '.list-inline.tab-bar.inset-panel'
+treeViewTab = root.querySelector '.tab[data-type="TreeView"]'
 treeViewTitles = document.querySelectorAll('.tree-view span.name')
 
 module.exports =
@@ -26,9 +26,9 @@ module.exports =
 
 showTabBarInTreeView = (boolean) ->
   if boolean
-    tabsInTreeView.style.display = 'flex'
+    treeViewTab.parentElement.style.display = 'flex'
   else
-    tabsInTreeView.style.display = 'none'
+    treeViewTab.parentElement.style.display = 'none'
 
 
 setSize = (currentFontSize) ->


### PR DESCRIPTION
This PR fixes #48 as it references to tree view tab indirectly (finds the parent element of `.tab[data-type='TreeView']`) instead of hiding the first one.

Works for me!